### PR TITLE
Production run to update gap_products (29 Sept 2025) 

### DIFF
--- a/code/run.R
+++ b/code/run.R
@@ -78,5 +78,6 @@ file.edit("code/direct_upload_akfin.R")
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 source("functions/archive_gap_products.R") 
 archive_gap_products(path = "temp/", 
-                     archive_path = "Y:/RACE_GF/GAP_PRODUCTS_Archives")
+                     archive_path = "V:/GAP_PRODUCTS_Archives")
+
 

--- a/code/update_production_tables.R
+++ b/code/update_production_tables.R
@@ -40,9 +40,15 @@ all_tables <- c("agecomp", "sizecomp", "biomass", "cpue")
 ##   areas, updated gapindex package, etc.) 
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 detailed_notes <- 
-  "Run completed by: Zack Oyafuso
-  
-This run was conducted to update cpue, biomass, and sizecomp after the Gulf of Alaska and Eastern Bering Sea 2025 bottom trawl surveys. This first run is primarily for Groundfish Plan Team Meetings in September 2025. Ages from 2025 have not been updated into the database yet. 
+  "Run completed by: Duane Stevenson
+ 
+-- This run was conducted primarily to update cpue, biomass, and sizecomp after the Northern Bering Sea 2025 bottom trawl survey.
+
+-- The skate complex aggregation (400) and Bathyraja spp. aggregation (405) was adjusted to account for the Genus name change Arctoraja parmifera (formerly Bathyraja parmifera) for all survey regions. See details in github issue: https://github.com/afsc-gap-products/gap_products/issues/78.
+
+-- Age compositions were updated to account for new GOA northern rock sole (2021) and NBS pollock (2023) aged otolith data. 
+
+-- A Bering sea slope Kamchatka flounder specimen record with a negative age was corrected. This correction slightly adjusted the age compositions. See details in github issue: https://github.com/afsc-gap-products/data-requests/issues/108.
 "
 
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/content/intro-news/2025-09-29.txt
+++ b/content/intro-news/2025-09-29.txt
@@ -1,0 +1,89 @@
+GAP_PRODUCTS ChangeLog (last produced on 2025-09-29) using gapindex v3.0.3
+Run completed by: Duane Stevenson
+ 
+-- This run was conducted to update agecomp tables after receiving age data from walleye pollock otoliths collected on the 2025 EBS bottom trawl survey.
+
+
+
+
+ AI Region: 
+
+ cpue : 
+ 0 new cpue records, 0 cpue removed records, and  0 modified cpue records.
+
+ biomass : 
+ 0 new biomass records, 0 biomass removed records, and  0 modified biomass records.
+
+ sizecomp : 
+ 0 new sizecomp records, 0 sizecomp removed records, and  0 modified sizecomp records.
+
+ agecomp : 
+ 0 new agecomp records, 0 agecomp removed records, and  0 modified agecomp records.
+
+
+
+ GOA Region: 
+
+ cpue : 
+ 0 new cpue records, 0 cpue removed records, and  0 modified cpue records.
+
+ biomass : 
+ 0 new biomass records, 0 biomass removed records, and  0 modified biomass records.
+
+ sizecomp : 
+ 0 new sizecomp records, 0 sizecomp removed records, and  0 modified sizecomp records.
+
+ agecomp : 
+ 0 new agecomp records, 0 agecomp removed records, and  0 modified agecomp records.
+
+
+
+ EBS Region: 
+
+ cpue : 
+ 0 new cpue records, 0 cpue removed records, and  0 modified cpue records.
+
+ biomass : 
+ 0 new biomass records, 0 biomass removed records, and  0 modified biomass records.
+
+ sizecomp : 
+ 0 new sizecomp records, 0 sizecomp removed records, and  0 modified sizecomp records.
+
+ agecomp : 
+ 741 new agecomp records, 20 agecomp removed records, and  52 modified agecomp records.
+
+
+
+ NBS Region: 
+
+ cpue : 
+ 0 new cpue records, 0 cpue removed records, and  0 modified cpue records.
+
+ biomass : 
+ 0 new biomass records, 0 biomass removed records, and  0 modified biomass records.
+
+ sizecomp : 
+ 0 new sizecomp records, 0 sizecomp removed records, and  0 modified sizecomp records.
+
+ agecomp : 
+ 0 new agecomp records, 0 agecomp removed records, and  0 modified agecomp records.
+
+
+
+ BSS Region: 
+
+ cpue : 
+ 0 new cpue records, 0 cpue removed records, and  0 modified cpue records.
+
+ biomass : 
+ 0 new biomass records, 0 biomass removed records, and  0 modified biomass records.
+
+ sizecomp : 
+ 0 new sizecomp records, 0 sizecomp removed records, and  0 modified sizecomp records.
+
+ agecomp : 
+ 0 new agecomp records, 0 agecomp removed records, and  0 modified agecomp records.
+
+
+
+


### PR DESCRIPTION
Update of agecomp tables after receipt of 2025 pollock ages from the EBS.